### PR TITLE
Add accessible name to button on  the "Tags" site of Teedy.

### DIFF
--- a/docs-web/src/main/webapp/src/partial/docs/tag.html
+++ b/docs-web/src/main/webapp/src/partial/docs/tag.html
@@ -17,7 +17,7 @@
         <div class="input-group" ng-class="{ 'has-error': !tagForm.color.$valid && tagForm.$dirty }">
           <span colorpicker class="input-group-addon btn btn-default" data-color="#3a87ad" ng-model="tag.color" ng-style="{ 'background': tag.color }">&nbsp;</span>
           <input type="text" name="color" class="form-control" ng-maxlength="7" ng-model="tag.color" ng-show="hexaField">
-          <button class="btn btn-default" ng-click="hexaField = true" ng-show="!hexaField"><span class="fas fa-microchip"></span></button>
+          <button class="btn btn-default" ng-click="hexaField = true" ng-show="!hexaField" aria-label="Add tag"><span class="fas fa-microchip"></span></button>
         </div>
         <div class="form-group" ng-class="{ 'has-error': !tagForm.name.$valid && tagForm.$dirty }">
           <input type="text" name="name" ng-attr-placeholder="{{ 'tag.new_tag' | translate }}" class="form-control"


### PR DESCRIPTION
Resolve #56 by adding an aria-label attribute to the button in the docs/tag.html file, since the button does not have a visible label.

The accessibility score for the "Tags" site went from 84 to 92.